### PR TITLE
FIX README typo for the git install commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ FakeEmail is installed using the setup.py and depends on Twisted for it's server
 
   git clone git://github.com/tomwardill/FakeEmail.git
   cd FakeEmail
-  python setupy.py install
+  python setup.py install
   
   
 Usage


### PR DESCRIPTION
Hi, thank's for this great tool. I fixed this little typo that can be a little confusing for those that just copy/paste commands from your README.
Have a nice day.
